### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/Easterj756/a1b9548b-45cd-4033-a29f-44933fa799cf/eda258bd-cdf2-432a-8245-73d86dc728e4/_apis/work/boardbadge/957ce283-1ba1-45bf-8331-0db728989ac0)](https://dev.azure.com/Easterj756/a1b9548b-45cd-4033-a29f-44933fa799cf/_boards/board/t/eda258bd-cdf2-432a-8245-73d86dc728e4/Microsoft.RequirementCategory)
 # hope
 Help


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/Easterj756/a1b9548b-45cd-4033-a29f-44933fa799cf/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.